### PR TITLE
Add optional vllm backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ A Python package for redacting Personally Identifiable Information (PII) from te
 pip install pii-redaction
 ```
 
+To use the faster `vllm` backend, install with the optional `vllm` extra:
+
+```bash
+pip install pii-redaction[vllm]
+```
+
 Or install from source:
 
 ```bash
@@ -32,6 +38,7 @@ pii-redact process-jsonl input.jsonl output.jsonl
 
 Options:
 - `--device`: Device to use for processing (e.g., cuda, cpu)
+- `--engine`: Generation backend (`transformers` or `vllm`)
 - PII handling modes (mutually exclusive):
   - `--tag`: Keep PII content between XML tags (default) `<PII:type>content</PII:type>`
   - `--redact`: Replace PII with just an empty tag `<PII:type/>`
@@ -48,6 +55,7 @@ pii-redact process-text input.txt output.txt
 
 Options:
 - `--device`: Device to use for processing (e.g., cuda, cpu)
+- `--engine`: Generation backend (`transformers` or `vllm`)
 - PII handling modes (mutually exclusive):
   - `--tag`: Keep PII content between XML tags (default) `<PII:type>content</PII:type>`
   - `--redact`: Replace PII with just an empty tag `<PII:type/>`
@@ -93,31 +101,41 @@ documents = [
 ]
 
 # Tag PII (default mode)
-tagged_documents = tag_pii_in_documents(documents, mode=PIIHandlingMode.TAG)
+tagged_documents = tag_pii_in_documents(
+    documents,
+    mode=PIIHandlingMode.TAG,
+    engine="transformers",
+)
 
 # Redact PII completely
-redacted_documents = tag_pii_in_documents(documents, mode=PIIHandlingMode.REDACT)
+redacted_documents = tag_pii_in_documents(
+    documents,
+    mode=PIIHandlingMode.REDACT,
+    engine="transformers",
+)
 
 # Replace PII with fake data
 anonymized_documents = tag_pii_in_documents(
-    documents, 
+    documents,
     mode=PIIHandlingMode.REPLACE,
-    locale="en_US"
+    locale="en_US",
+    engine="transformers",
 )
 
 # Process a JSONL dataset
 # Tag PII (default mode)
-clean_dataset('input.jsonl', 'output.jsonl', mode=PIIHandlingMode.TAG)
+clean_dataset('input.jsonl', 'output.jsonl', mode=PIIHandlingMode.TAG, engine="transformers")
 
 # Redact PII in a JSONL dataset
-clean_dataset('input.jsonl', 'redacted.jsonl', mode=PIIHandlingMode.REDACT)
+clean_dataset('input.jsonl', 'redacted.jsonl', mode=PIIHandlingMode.REDACT, engine="transformers")
 
 # Replace PII with fake data in a JSONL dataset
 clean_dataset(
-    'input.jsonl', 
-    'anonymized.jsonl', 
+    'input.jsonl',
+    'anonymized.jsonl',
     mode=PIIHandlingMode.REPLACE,
-    locale="en_US"
+    locale="en_US",
+    engine="transformers"
 )
 ```
 

--- a/pii_redaction/cli.py
+++ b/pii_redaction/cli.py
@@ -40,6 +40,12 @@ def main():
             default="en_US",
             help="Locale for generating fake data (default: en_US, only used with --replace)",
         )
+        parser.add_argument(
+            "--engine",
+            choices=["transformers", "vllm"],
+            default="transformers",
+            help="Generation backend to use (default: transformers)",
+        )
 
     # Process JSONL dataset command
     jsonl_parser = subparsers.add_parser(
@@ -70,6 +76,7 @@ def main():
             args.input,
             args.output,
             device=args.device,
+            engine=args.engine,
             mode=args.mode,
             locale=args.locale,
         )
@@ -78,7 +85,11 @@ def main():
             documents = [line.strip() for line in f if line.strip()]
 
         tagged_documents = tag_pii_in_documents(
-            documents, device=args.device, mode=args.mode, locale=args.locale
+            documents,
+            device=args.device,
+            engine=args.engine,
+            mode=args.mode,
+            locale=args.locale,
         )
 
         with open(args.output, "w") as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
     "faker>=8.0.0",
 ]
 
+[project.optional-dependencies]
+vllm = ["vllm>=0.2.0"]
+
 [project.urls]
 Homepage = "https://github.com/OpenPipe/pii-redaction"
 


### PR DESCRIPTION
## Summary
- add vllm optional dependency
- allow choosing generation engine in CLI and API
- update docs for vllm usage

## Testing
- `python -m py_compile pii_redaction/*.py`
- `pytest -q`