### PR TITLE
Fix vllm prompt formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ For handling PII in plain text files (one document per line):
 pii-redact process-text input.txt output.txt
 ```
 
+This command streams the input file line by line, writing each processed
+document to the output file immediately. This avoids keeping all processed
+documents in memory and works well with large files.
+
 Options:
 - `--device`: Device to use for processing (e.g., cuda, cpu)
 - `--engine`: Generation backend (`transformers` or `vllm`)

--- a/pii_redaction/cli.py
+++ b/pii_redaction/cli.py
@@ -81,20 +81,19 @@ def main():
             locale=args.locale,
         )
     elif args.command == "process-text":
-        with open(args.input, "r") as f:
-            documents = [line.strip() for line in f if line.strip()]
+        with open(args.input, "r") as fin:
+            doc_count = sum(1 for _ in fin)
 
-        tagged_documents = tag_pii_in_documents(
-            documents,
-            device=args.device,
-            engine=args.engine,
-            mode=args.mode,
-            locale=args.locale,
-        )
-
-        with open(args.output, "w") as f:
-            for doc in tagged_documents:
-                f.write(doc + "\n")
+        with open(args.input, "r") as fin, open(args.output, "w") as fout:
+            documents = (line.strip() for line in fin if line.strip())
+            tag_pii_in_documents(
+                documents,
+                device=args.device,
+                engine=args.engine,
+                mode=args.mode,
+                locale=args.locale,
+                output_file=fout,
+            )
 
         mode_descriptions = {
             PIIHandlingMode.TAG: "Tagged",
@@ -102,9 +101,7 @@ def main():
             PIIHandlingMode.REPLACE: "Replaced",
         }
         action = mode_descriptions[args.mode]
-        print(
-            f"{action} PII in {len(tagged_documents)} documents and saved to {args.output}"
-        )
+        print(f"{action} PII in {doc_count} documents and saved to {args.output}")
     else:
         parser.print_help()
 


### PR DESCRIPTION
## Summary
- always output a plain string from `apply_chat_template` for vLLM engine
- stream document processing to an output file to avoid large memory use

## Testing
- `pytest -q`
